### PR TITLE
make_name_with_pathcheck() 修正

### DIFF
--- a/src/lhext.c
+++ b/src/lhext.c
@@ -99,6 +99,7 @@ make_name_with_pathcheck(char *name, size_t namesz, const char *q)
         offset += sz;
     }
 
+#ifdef S_IFLNK
     while ((p = strchr(q, '/')) != NULL) {
         if (namesz - offset < (p - q) + 2) {
             return FALSE;
@@ -118,6 +119,7 @@ make_name_with_pathcheck(char *name, size_t namesz, const char *q)
         }
         name[offset++] = '/';
     }
+#endif
 
     str_safe_copy(name + offset, q, namesz - offset);
 

--- a/src/lhext.c
+++ b/src/lhext.c
@@ -84,7 +84,7 @@ inquire_extract(name)
 }
 
 static boolean
-make_name_with_pathcheck(char *name, size_t namesz, const char *dir, const char *q)
+make_name_with_pathcheck(char *name, size_t namesz, const char *q)
 {
     int offset = 0;
     const char *p;
@@ -295,7 +295,7 @@ extract_one(afp, hdr)
         }
     }
 
-    if (!make_name_with_pathcheck(name, sizeof(name), extract_directory, q)) {
+    if (!make_name_with_pathcheck(name, sizeof(name), q)) {
         error("Possible symlink traversal hack attempt in %s", q);
         exit(1);
     }


### PR DESCRIPTION
* 引数 dir は使用されていない
* lstat をサポートしていない環境でビルドに失敗する

の2点を修正しました。