### PR TITLE
Change skip behavior on extracting.

### DIFF
--- a/src/lhext.c
+++ b/src/lhext.c
@@ -432,11 +432,11 @@ extract_one(afp, hdr)
 
             if (skip_flg == TRUE) { /* if skip_flg */
                 if (stat(name, &stbuf) == 0 && force != TRUE) {
-                    if (stbuf.st_mtime >= hdr->unix_last_modified_stamp) {
+                    /* if (stbuf.st_mtime >= hdr->unix_last_modified_stamp) {*/
                         if (quiet != TRUE)
                             printf("%s : Skipped...\n", name);
                         return read_size;
-                    }
+                    /* } */
                 }
             }
             if (noexec) {
@@ -515,13 +515,15 @@ extract_one(afp, hdr)
                     if (up_flag == FALSE && force == FALSE) {
                         return read_size;
                     }
-                } else {
+                }
+
+                if (skip_flg == TRUE) { /* if skip_flg */
                     if (GETSTAT(name, &stbuf) == 0 && force != TRUE) {
-                        if (stbuf.st_mtime >= hdr->unix_last_modified_stamp) {
+                        /* if (stbuf.st_mtime >= hdr->unix_last_modified_stamp) { */
                             if (quiet != TRUE)
                                 printf("%s : Skipped...\n", name);
                             return read_size;
-                        }
+                        /* } */
                     }
                 }
 


### PR DESCRIPTION
解凍においてファイルが上書きになる場合に "Skip" を選択しても、
従来の動作ではアーカイブ中のファイルのタイムスタンプが新しい場合
上書きされます。

タイムスタンプによらずスキップする動作が無いのは不便と思われましたので、
"Skip" をタイムスタンプによらずスキップする動作に変更し、新たに
"Timestamp" を追加してタイムスタンプをチェックする動作としました。