### PR TITLE
Fix path check

### DIFF
--- a/src/lharc.c
+++ b/src/lharc.c
@@ -1003,7 +1003,7 @@ include_path_p(path, name)
     char           *n = name;
     while (*path)
         if (*path++ != *n++)
-            return (path[-1] == '/' && *n == '\0');
+            return (path[-1] == '/' && n[-1] == '\0');
     return (*n == '/' || (n != name && path[-1] == '/' && n[-1] == '/'));
 }
 


### PR DESCRIPTION
lha c において、ディレクトリを最後に '/' を付けて指定した後に、ディレクトリ名より1文字だけ多いファイル名のファイルを指定すると、ファイルがアーカイブに格納されません。

実行例:
    mkdir test
    touch testf
    lha c test.lzh test/ testf
    lha l test.lzh

実行結果:
    PERMISSION  UID  GID      SIZE  RATIO     STAMP           NAME
    ---------- ----------- ------- ------ ------------ --------------------
    drwxrwxr-x   500/500         0 ****** Oct 14 18:16 test/
    ---------- ----------- ------- ------ ------------ --------------------
     Total         1 file        0 ****** Oct 14 18:16

ディレクトリを指定した場合に、後続のディレクトリ/ファイル指定のうち、そのディレクトリに含まれるものを除外する処理を cleaning_files() で行っていますが、 include_path_p() の判定に誤りがあったため、上記の例のような場合に testf が test/ ディレクトリ外にもかかわらず除外されていました。