### PR TITLE
Fix autoconf issues with Xcode 12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,14 +129,14 @@ AC_CACHE_CHECK([whether strchr()/strrchr() is 8bit clean],
 char *strchr (), *strrchr ();
 #endif
 
-main()
+int main()
 {
   char *s = "\377";
-  if (strchr(s, 0xff) != s) exit(1);
-  if (strchr(s, '\377') != s) exit(1);
-  if (strrchr(s, 0xff) != s) exit(1);
-  if (strrchr(s, '\377') != s) exit(1);
-  exit(0); /* ok */
+  if (strchr(s, 0xff) != s) return 1;
+  if (strchr(s, '\377') != s) return 1;
+  if (strrchr(s, 0xff) != s) return 1;
+  if (strrchr(s, '\377') != s) return 1;
+  return 0; /* ok */
 }
 ], lha_cv_func_strchr_8bit_clean=yes,
    lha_cv_func_strchr_8bit_clean=no,
@@ -163,19 +163,19 @@ AC_CACHE_CHECK([whether the 2nd argument of gettimeofday() is effective],
 # endif
 #endif
 
-main()
+int main()
 {
     struct timeval tv;
     struct timezone tz;
 
     tz.tz_minuteswest = -1;
     if (gettimeofday(&tv, &tz) == -1)
-        exit(1);
+        return 1;
 
     if (tz.tz_minuteswest == -1)
-        exit(1);	/* the timezone information is no given */
+        return 1;	/* the timezone information is no given */
 
-    exit(0);
+    return 0;
 }], lha_cv_func_gettimeofday_2nd_arg=yes,
    lha_cv_func_gettimeofday_2nd_arg=no,
    lha_cv_func_gettimeofday_2nd_arg=no))


### PR DESCRIPTION
Xcode 12 decided to make `-Wimplicit-function-declaration `an error by default.  This means if you call `exit()` without first `#include <stdlib.h>` you get an error.  This means that the `./configure` script ends up mis-detecting some things, causing confusing build failures later.

This could be fixed by adding the missing `#include`, but it's even easier to switch to just returning from `main()` directly.

While I'm here, change `main()` to be explicitly defined as returning `int` -- the default-to-`int` behavior of ancient C is deprecated since C99 so neglecting it might cause issues in the future.