### PR TITLE
Add README.md and header.doc.md into tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ## Process this file with automake to produce Makefile.in
 
 AUTOMAKE_OPTIONS = foreign
-EXTRA_DIST = README.jp.md header.doc.jp Hacking_of_LHa
+EXTRA_DIST = README.md README.jp.md header.doc.md header.doc.jp Hacking_of_LHa
 SUBDIRS= man olddoc src tests


### PR DESCRIPTION
Add README.md and header.doc.md to EXTRA_DIST in Makefile.am, to
make these files included in the tarball.