### PR TITLE
Change behavior of overwriting symbolic link during extraction.

### DIFF
--- a/src/lha_macro.h
+++ b/src/lha_macro.h
@@ -186,7 +186,11 @@
 /*  FILE Attribute                                                          */
 /* ------------------------------------------------------------------------ */
 #define is_directory(statp)     (((statp)->st_mode & S_IFMT) == S_IFDIR)
+#ifdef S_IFLNK
 #define is_symlink(statp)       (((statp)->st_mode & S_IFMT) == S_IFLNK)
+#else
+#define is_symlink(statp)       (FALSE)
+#endif
 #define is_regularfile(statp)   (((statp)->st_mode & S_IFMT) == S_IFREG)
 
 #if 1 /* assume that fopen() will accepts "b" as binary mode on all systems. */

--- a/src/lhadd.c
+++ b/src/lhadd.c
@@ -123,11 +123,7 @@ append_it(name, oafp, nafp)
     }
 
     directory = is_directory(&stbuf);
-#ifdef S_IFLNK
     symlink = is_symlink(&stbuf);
-#else
-    symlink = 0;
-#endif
 
     fp = NULL;
     if (!directory && !symlink && !noexec) {
@@ -449,7 +445,6 @@ remove_one(name)
         else if (verbose)
             message("Removed %s.", name);
     }
-#ifdef S_IFLNK
     else if (is_symlink(&stbuf)) {
         if (noexec)
             message("REMOVE SYMBOLIC LINK %s.", name);
@@ -458,7 +453,6 @@ remove_one(name)
         else if (verbose)
             message("Removed %s.", name);
     }
-#endif
     else {
         error("Cannot remove file \"%s\" (not a file or directory)", name);
     }

--- a/src/lharc.c
+++ b/src/lharc.c
@@ -1041,10 +1041,8 @@ cleaning_files(v_filec, v_filev)
                 flags[i] = 0x00;
             else if (is_directory(&stbuf))
                 flags[i] = 0x02;
-#ifdef S_IFLNK
             else if (is_symlink(&stbuf)) /* t.okamoto */
                 flags[i] = 0x00;
-#endif
             else {
                 flags[i] = 0x04;
                 warning("Cannot archive \"%s\", ignored.", filev[i]);

--- a/src/lhext.c
+++ b/src/lhext.c
@@ -41,8 +41,8 @@ inquire_extract(name)
     struct stat     stbuf;
 
     skip_flg = FALSE;
-    if (stat(name, &stbuf) >= 0) {
-        if (!is_regularfile(&stbuf)) {
+    if (GETSTAT(name, &stbuf) >= 0) {
+        if (!is_regularfile(&stbuf) && !is_symlink(&stbuf)) {
             error("\"%s\" already exists (not a file)", name);
             return FALSE;
         }


### PR DESCRIPTION
Current behavior of overwriting a symbolic link with a regular file
depends on a file type the symbolic link refers to.
When it refers to a regular file, lha asks whether to overwrite or not.
When it refers to a directory or a special file, lha fails to overwrite.
When it refers to broken link, lha silently overwrite.

The fix changes to ask whether to overwrite for all these cases.