### PR TITLE
Add missing test files into tarball.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,6 +7,9 @@ EXTRA_DIST =	lha-test1 \
 		lha-test5 \
 		lha-test6 \
 		lha-test7 \
+		lha-test7_lv0 \
+		lha-test7_lv1 \
+		lha-test7_lvg \
 		lha-test8 \
 		lha-test9 \
 		lha-test10 \


### PR DESCRIPTION
tests/lha-test7_lv*がtarballに含まれていなかったのを修正しました。