### PR TITLE
Fix date if local timestamp is a day early.

### DIFF
--- a/tests/lha-test20
+++ b/tests/lha-test20
@@ -11,7 +11,8 @@ do
 	do
 $lha l --archive-kanji-code=$acode --system-kanji-code=$scode \
 	$srcdir/lha-test20-$acode.lzh | \
-	sed '$d' | diff - $srcdir/lha-test20-list-$scode.txt
+	sed -e '$d' -e 's/Jan  1  2000/Jan  2  2000/' | \
+    diff - $srcdir/lha-test20-list-$scode.txt
 							check $? $LINENO
 	done
 done

--- a/tests/lha-test20
+++ b/tests/lha-test20
@@ -12,7 +12,7 @@ do
 $lha l --archive-kanji-code=$acode --system-kanji-code=$scode \
 	$srcdir/lha-test20-$acode.lzh | \
 	sed -e '$d' -e 's/Jan  1  2000/Jan  2  2000/' | \
-    diff - $srcdir/lha-test20-list-$scode.txt
+	diff - $srcdir/lha-test20-list-$scode.txt
 							check $? $LINENO
 	done
 done


### PR DESCRIPTION
On my machine, `lha` outputs the local timestamp of the compressed test files in `lha-test20-*.lzh` as Jan 1, 2000. But the expected timestamp is Jan 2, 2000. I think that this is because my computer is in Eastern time (UTC−05:00), so the timestamp is being converted to that timezone, making it show up as modified a day earlier.

In order to make the tests pass, I added an expression in `sed` to change the date outputted by `lha` to match the expected date only if the date is a day earlier. If the issue is really because the compressed file's timestamp is being converted to eastern time, then this should be ok.