### PR TITLE
Update header.c

### DIFF
--- a/src/header.c
+++ b/src/header.c
@@ -69,6 +69,7 @@ calc_sum(p, len)
 
 static void
 _skip_bytes(len)
+    int len;
 {
     if (len < 0) {
       error("Invalid header: %d", len);


### PR DESCRIPTION
header.c: In function ‘_skip_bytes’:
header.c:71:1: warning: type of ‘len’ defaults to ‘int’ [-Wimplicit-int]
   71 | _skip_bytes(len)
      | ^~~~~~~~~~~