### PR TITLE
GNU getopt not always used when USE_GNU is defined

### DIFF
--- a/src/lharc.c
+++ b/src/lharc.c
@@ -207,7 +207,11 @@ commands:                           options:\n\
 ");
 }
 
+#if USE_GNU
+#include <getopt.h>  /* use GNU getopt_long() */
+#else
 #include "getopt_long.h"
+#endif
 
 /*
   Parse LHA options


### PR DESCRIPTION
Missing include guard leads to GNU getopt being used in some cases and getopt_long in others.