### PR TITLE
Introduce dynamic versioning with gen-build-version.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ olddoc/Makefile
 olddoc/Makefile.in
 .deps/
 src/lha
+src/version.h
 src/Makefile
 src/Makefile.in
 stamp-h1

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,13 @@
 ## Process this file with automake to produce Makefile.in
 
 AUTOMAKE_OPTIONS = foreign
-EXTRA_DIST = README.md README.jp.md header.doc.md header.doc.jp Hacking_of_LHa
+EXTRA_DIST = README.md README.jp.md header.doc.md header.doc.jp Hacking_of_LHa autogen.sh build-aux/gen-build-version.sh
 SUBDIRS= man olddoc src tests
+
+.tarball-version:
+	sh $(top_srcdir)/build-aux/gen-build-version.sh --dist > .tarball-version
+
+pre-configure: .tarball-version
+
+dist-hook: .tarball-version
+	mv .tarball-version $(distdir)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Exit on error
+set -e
+
+# Check for dependencies
+if ! command -v git &>/dev/null; then
+    echo "git is required but not found. Exiting."
+    exit 1
+fi
+
+# Run autoreconf to generate configure script
+autoreconf --force --install --symlink
+
+# Run configure
+mkdir build 2>/dev/null || true
+cd build && ../configure "$@"

--- a/build-aux/gen-build-version.sh
+++ b/build-aux/gen-build-version.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Print version string derived from Git or .tarball-version
+# If called with --dist, generate .tarball-version with simplified version
+
+set -e
+
+top_srcdir=$(dirname $0)/..
+
+VERSION_PREFIX="1.14i-ac"
+
+# Use Git info to generate full version
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  IS_INSIDE_WORK_TREE=true
+  DATE=$(git log -1 --date=format:"%Y%m%d" --pretty=format:"%cd")
+  HASH=$(git rev-parse --short=7 HEAD)
+
+  DIRTY=""
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    DIRTY="-dirty"
+    echo "Warning: repository is dirty (has uncommitted changes)" >&2
+  fi
+fi
+
+# --dist: output version for .tarball-version and exit
+if test "$1" = "--dist"; then
+  if test x"$DIRTY" != x; then
+    exit 1
+  fi
+
+  if test "$IS_INSIDE_WORK_TREE" = true; then
+    echo "${VERSION_PREFIX}${DATE}"
+    exit 0
+  else
+    echo "Error: not inside a Git repository" >&2
+    exit 1
+  fi
+fi
+
+# Use .tarball-version if present
+if test -f $top_srcdir/.tarball-version; then
+  cat $top_srcdir/.tarball-version
+  exit 0
+fi
+
+if test "$IS_INSIDE_WORK_TREE" = true; then
+  echo "${VERSION_PREFIX}${DATE}-${HASH}${DIRTY}"
+  exit 0
+fi
+
+# Fallback if nothing is available
+echo "${VERSION_PREFIX}unknown"
+exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT([LHa for UNIX], 1.14i-ac20220213, jca02266@gmail.com, lha)
+m4_define([VERSION_STRING], m4_esyscmd_s([build-aux/gen-build-version.sh --dist]))
+AC_INIT([LHa for UNIX], VERSION_STRING, [jca02266@gmail.com], [lha])
 AC_DEFINE_UNQUOTED(LHA_CONFIGURE_OPTIONS, "$ac_configure_args",
             [specified options for the configure script.])
 AC_CANONICAL_HOST

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,17 @@ lha_SOURCES = append.c bitio.c crcio.c dhuf.c extract.c header.c huf.c \
 	lhext.c lhlist.c maketbl.c maketree.c patmatch.c shuf.c slide.c \
 	util.c getopt_long.c getopt_long.h \
 	pm2.c pm2hist.c pm2tree.c \
-	support_utf8.c
+	support_utf8.c version.h.in
 lha_LDADD = @LIBOBJS@
 EXTRA_DIST = lhdir.h fnmatch.h
 AM_CPPFLAGS=$(DEF_KCODE) $(SUPPORT_LZHUFF_METHOD)
+
+BUILT_SOURCES = version.h
+CLEANFILES = version.h
+
+version.h: FORCE
+	@echo "Generating version.h..."
+	@BUILD_VERSION=`sh $(top_srcdir)/build-aux/gen-build-version.sh`; \
+	sed "s|@BUILD_VERSION@|$$BUILD_VERSION|" $(srcdir)/version.h.in > $@
+
+FORCE:

--- a/src/lharc.c
+++ b/src/lharc.c
@@ -726,14 +726,16 @@ main(argc, argv)
 
 
 /* ------------------------------------------------------------------------ */
+#include "version.h"
+
 static void
 print_version()
 {
     /* macro PACKAGE_NAME, PACKAGE_VERSION and PLATFORM are
        defined in config.h by configure script */
     fprintf(stdout, "%s version %s (%s)\n",
-            PACKAGE_NAME, PACKAGE_VERSION, PLATFORM);
-    
+            PACKAGE_NAME, BUILD_VERSION, PLATFORM);
+
     if (strlen(LHA_CONFIGURE_OPTIONS) != 0)
       fprintf(stdout, "  configure options: %s\n", LHA_CONFIGURE_OPTIONS);
 }

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,1 @@
+#define BUILD_VERSION "@BUILD_VERSION@"


### PR DESCRIPTION
Generates version strings from the latest Git commit hash when inside a Git work tree, or from .tarball-version when building from a release archive. With the --dist option, omits the commit hash for distribution builds. Automatically generates .tarball-version during 'make dist' and includes it in the tarball.