### PR TITLE
Replace "egrep" commands with "grep -E" for test/lha-test1{0,1,3,4,7}

### DIFF
--- a/tests/lha-test10
+++ b/tests/lha-test10
@@ -18,11 +18,11 @@ $lha vv test-tmp-h1.lzh
 							check $? $LINENO
 $lha vv test-tmp-h2.lzh
 							check $? $LINENO
-$lha vv test-tmp-h0.lzh | egrep '\[0\].?$'
+$lha vv test-tmp-h0.lzh | grep -E '\[0\].?$'
 							check $? $LINENO
-$lha vv test-tmp-h1.lzh | egrep '\[1\].?$'
+$lha vv test-tmp-h1.lzh | grep -E '\[1\].?$'
 							check $? $LINENO
-$lha vv test-tmp-h2.lzh | egrep '\[2\].?$'
+$lha vv test-tmp-h2.lzh | grep -E '\[2\].?$'
 							check $? $LINENO
 diff -r test-1 test-tmp-h0/test-1
 							check $? $LINENO
@@ -56,11 +56,11 @@ $lha vv test-tmp2-h1.lzh
 							check $? $LINENO
 $lha vv test-tmp2-h2.lzh
 							check $? $LINENO
-$lha vv test-tmp2-h0.lzh | egrep '\[0\].?$'
+$lha vv test-tmp2-h0.lzh | grep -E '\[0\].?$'
 							check $? $LINENO
-$lha vv test-tmp2-h1.lzh | egrep '\[1\].?$'
+$lha vv test-tmp2-h1.lzh | grep -E '\[1\].?$'
 							check $? $LINENO
-$lha vv test-tmp2-h2.lzh | egrep '\[2\].?$'
+$lha vv test-tmp2-h2.lzh | grep -E '\[2\].?$'
 							check $? $LINENO
 diff test-a test-tmp2-h0/test-tmp-d1/test-a
 							check $? $LINENO
@@ -101,11 +101,11 @@ $lha vv test-tmp-hg1.lzh
 							check $? $LINENO
 $lha vv test-tmp-hg2.lzh
 							check $? $LINENO
-$lha vv test-tmp-hg0.lzh | egrep '\[0\].?$'
+$lha vv test-tmp-hg0.lzh | grep -E '\[0\].?$'
 							check $? $LINENO
-$lha vv test-tmp-hg1.lzh | egrep '\[1\].?$'
+$lha vv test-tmp-hg1.lzh | grep -E '\[1\].?$'
 							check $? $LINENO
-$lha vv test-tmp-hg2.lzh | egrep '\[2\].?$'
+$lha vv test-tmp-hg2.lzh | grep -E '\[2\].?$'
 							check $? $LINENO
 diff -r test-1 test-tmp-hg0/test-1
 							check $? $LINENO
@@ -140,11 +140,11 @@ $lha vv test-tmp2-hg1.lzh
 							check $? $LINENO
 $lha vv test-tmp2-hg2.lzh
 							check $? $LINENO
-$lha vv test-tmp2-hg0.lzh | egrep '\[0\].?$'
+$lha vv test-tmp2-hg0.lzh | grep -E '\[0\].?$'
 							check $? $LINENO
-$lha vv test-tmp2-hg1.lzh | egrep '\[1\].?$'
+$lha vv test-tmp2-hg1.lzh | grep -E '\[1\].?$'
 							check $? $LINENO
-$lha vv test-tmp2-hg2.lzh | egrep '\[2\].?$'
+$lha vv test-tmp2-hg2.lzh | grep -E '\[2\].?$'
 							check $? $LINENO
 diff test-a test-tmp2-hg0/test-tmp-gd1/test-a
 							check $? $LINENO

--- a/tests/lha-test11
+++ b/tests/lha-test11
@@ -61,13 +61,13 @@ $lha vv test-tmp1-h1.lzh
 							check $? $LINENO
 $lha vv test-tmp1-h2.lzh
 							check $? $LINENO
-$lha vv test-tmp1-hg.lzh | egrep '\[0\].?$'
+$lha vv test-tmp1-hg.lzh | grep -E '\[0\].?$'
 							check $? $LINENO
-$lha vv test-tmp1-h0.lzh | egrep '\[0\].?$'
+$lha vv test-tmp1-h0.lzh | grep -E '\[0\].?$'
 							check $? $LINENO
-$lha vv test-tmp1-h1.lzh | egrep '\[1\].?$'
+$lha vv test-tmp1-h1.lzh | grep -E '\[1\].?$'
 							check $? $LINENO
-$lha vv test-tmp1-h2.lzh | egrep '\[2\].?$'
+$lha vv test-tmp1-h2.lzh | grep -E '\[2\].?$'
 							check $? $LINENO
 test -f test-tmp1-hg/$(echo test-tmp1/$file | cut -c-233)
 							check $? $LINENO
@@ -88,7 +88,7 @@ else
 							check $? $LINENO
   $lha vv test-tmp4-h2.lzh
 							check $? $LINENO
-  $lha vv test-tmp4-h2.lzh | egrep '\[2\].?$'
+  $lha vv test-tmp4-h2.lzh | grep -E '\[2\].?$'
 							check $? $LINENO
   rm -f $file
 							check $? $LINENO

--- a/tests/lha-test13
+++ b/tests/lha-test13
@@ -24,7 +24,7 @@ esac
 $lha c test-tmp-euc.lzh test-tmp-euc
 							check $? $LINENO
 # file size is too small, so no compressed
-$lha v test-tmp-euc.lzh | egrep lh0
+$lha v test-tmp-euc.lzh | grep -E lh0
 							check $? $LINENO
 # no convert
 $lha xw=test-tmp-euc-d test-tmp-euc.lzh
@@ -45,7 +45,7 @@ test $? -ne 0
 $lha ce test-tmp-sjis.lzh test-tmp-euc
 							check $? $LINENO
 # file size is too small, so no compressed
-$lha v test-tmp-euc.lzh | egrep lh0
+$lha v test-tmp-euc.lzh | grep -E lh0
 							check $? $LINENO
 # no convert (CR LF to LF)
 $lha xtw=test-tmp-sjis-d test-tmp-sjis.lzh
@@ -75,7 +75,7 @@ done > test-tmp-sjis2
 # no convert
 $lha c test-tmp-euc2.lzh test-tmp-euc2
 							check $? $LINENO
-$lha v test-tmp-euc2.lzh | egrep 'lh[567]'
+$lha v test-tmp-euc2.lzh | grep -E 'lh[567]'
 							check $? $LINENO
 # no convert
 $lha xw=test-tmp-euc2-d test-tmp-euc2.lzh
@@ -95,7 +95,7 @@ test $? -ne 0
 # euc to sjis (LF to CR LF)
 $lha ce test-tmp-sjis2.lzh test-tmp-euc2
 							check $? $LINENO
-$lha v test-tmp-euc2.lzh | egrep 'lh[567]'
+$lha v test-tmp-euc2.lzh | grep -E 'lh[567]'
 							check $? $LINENO
 # no convert (CR LF to LF)
 $lha xtw=test-tmp-sjis2-d test-tmp-sjis2.lzh

--- a/tests/lha-test14
+++ b/tests/lha-test14
@@ -43,7 +43,7 @@ test -s test-tmp-stderr
 # '|' was changed into '_'.
 $lha v test-tmp-2.lzh
 							check $? $LINENO
-$lha v test-tmp-2.lzh | egrep 'test-tmp-_foo -> test-a'
+$lha v test-tmp-2.lzh | grep -E 'test-tmp-_foo -> test-a'
 							check $? $LINENO
 $lha xw=test-tmp-2 test-tmp-2.lzh 2> test-tmp-stderr
 							check $? $LINENO
@@ -60,7 +60,7 @@ $lha c test-tmp-3.lzh test-tmp-foo
 							check $? $LINENO
 $lha v test-tmp-3.lzh
 							check $? $LINENO
-$lha v test-tmp-3.lzh | egrep 'test-tmp-foo -> test-tmp-\|bar'
+$lha v test-tmp-3.lzh | grep -E 'test-tmp-foo -> test-tmp-\|bar'
 							check $? $LINENO
 $lha xw=test-tmp-3 test-tmp-3.lzh 2> test-tmp-stderr
 							check $? $LINENO

--- a/tests/lha-test17
+++ b/tests/lha-test17
@@ -16,7 +16,7 @@ EOF
 							check $? $LINENO
 
 $lha vvq test-tmp-1.lzh | head -1
-$lha vvq test-tmp-1.lzh | head -1 | egrep '^test-1/test-a$'
+$lha vvq test-tmp-1.lzh | head -1 | grep -E '^test-1/test-a$'
 							check $? $LINENO
 
 echo -------------------------------------------------------------------
@@ -32,7 +32,7 @@ EOF
 							check $? $LINENO
 
 $lha vvq test-tmp-2.lzh | head -1
-$lha vvq test-tmp-2.lzh | head -1 | egrep '^test-a$'
+$lha vvq test-tmp-2.lzh | head -1 | grep -E '^test-a$'
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # ../xx/xx/../xx (result: xx not "xx/xx")
@@ -51,7 +51,7 @@ EOF
 							check $? $LINENO
 
 $lha vvq test-tmp-3.lzh | head -1
-$lha vvq test-tmp-3.lzh | head -1 | egrep '^test-a$'
+$lha vvq test-tmp-3.lzh | head -1 | grep -E '^test-a$'
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # just a ".." (result: ".")
@@ -84,7 +84,7 @@ test-1/test-b
 test-1/test-c
 EOF
 
-egrep -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
+grep -E -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # "xx/./xx" -> "xx/xx"
@@ -97,7 +97,7 @@ cat <<"EOF" > test-tmp-expect
 test-1/test-a
 EOF
 
-egrep -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
+grep -E -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # "./xx/././xx" -> "xx/xx"
@@ -110,7 +110,7 @@ cat <<"EOF" > test-tmp-expect
 test-1/test-a
 EOF
 
-egrep -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
+grep -E -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # "xx/./xx/./././xx" -> "xx/xx/xx"
@@ -127,7 +127,7 @@ cat <<"EOF" > test-tmp-expect
 test-tmp-7/test-1/test-a
 EOF
 
-egrep -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
+grep -E -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # "./" -> "."
@@ -145,7 +145,7 @@ test-b
 test-c
 EOF
 
-egrep -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
+grep -E -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # "." -> "."
@@ -163,7 +163,7 @@ test-b
 test-c
 EOF
 
-egrep -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
+grep -E -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
 							check $? $LINENO
 echo -------------------------------------------------------------------
 # remove duplicated slash "xxx//xxx" -> "xxx/xxx"
@@ -187,6 +187,6 @@ test-b
 test-a
 EOF
 
-egrep -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
+grep -E -v -- '-lh' test-tmp-stdout | diff - test-tmp-expect
 							check $? $LINENO
 echo -------------------------------------------------------------------


### PR DESCRIPTION
This silences the warnings during `make check`;
> egrep: warning: egrep is obsolescent; using grep -E

The following files that have these issues fixed:
* tests/lha-test10
* tests/lha-test11
* tests/lha-test13
* tests/lha-test14
* tests/lha-test17

A snippet of the `make check` without this fix are as follows,
```
lha-test8 #19 ... ok
lha-test8 #20 ... ok
lha-test8 #21 ... ok
testing header level 0, 1, 2 and each generic headers
lha-test10 #1 ... ok
lha-test10 #2 ... ok
lha-test10 #3 ... ok
lha-test10 #4 ... ok
lha-test10 #5 ... ok
lha-test10 #6 ... ok
lha-test10 #7 ... ok
lha-test10 #8 ... ok
lha-test10 #9 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #10 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #11 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #12 ... ok
lha-test10 #13 ... ok
lha-test10 #14 ... ok
lha-test10 #15 ... ok
lha-test10 #16 ... ok
lha-test10 #17 ... ok
lha-test10 #18 ... ok
lha-test10 #19 ... ok
lha-test10 #20 ... ok
lha-test10 #21 ... ok
lha-test10 #22 ... ok
lha-test10 #23 ... ok
lha-test10 #24 ... ok
lha-test10 #25 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #26 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #27 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #28 ... ok
lha-test10 #29 ... ok
lha-test10 #30 ... ok
lha-test10 #31 ... ok
lha-test10 #32 ... ok
lha-test10 #33 ... ok
lha-test10 #34 ... ok
lha-test10 #35 ... ok
lha-test10 #36 ... ok
lha-test10 #37 ... ok
lha-test10 #38 ... ok
lha-test10 #39 ... ok
lha-test10 #40 ... ok
lha-test10 #41 ... ok
lha-test10 #42 ... ok
lha-test10 #43 ... ok
lha-test10 #44 ... ok
lha-test10 #45 ... ok
lha-test10 #46 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #47 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #48 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #49 ... ok
lha-test10 #50 ... ok
lha-test10 #51 ... ok
lha-test10 #52 ... ok
lha-test10 #53 ... ok
lha-test10 #54 ... ok
lha-test10 #55 ... ok
lha-test10 #56 ... ok
lha-test10 #57 ... ok
lha-test10 #58 ... ok
lha-test10 #59 ... ok
lha-test10 #60 ... ok
lha-test10 #61 ... ok
lha-test10 #62 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #63 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #64 ... ok
egrep: warning: egrep is obsolescent; using grep -E
lha-test10 #65 ... ok
lha-test10 #66 ... ok
lha-test10 #67 ... ok
lha-test10 #68 ... ok
lha-test10 #69 ... ok
lha-test10 #70 ... ok
lha-test10 #71 ... ok
lha-test10 #72 ... ok
lha-test10 #73 ... ok
lha-test10 #74 ... ok
testing the long filename support
lha-test11 #1 ... ok
lha-test11 #2 ... ok
lha-test11 #3 ... ok
```