### PR TITLE
Eliminate clang warning

### DIFF
--- a/src/append.c
+++ b/src/append.c
@@ -9,15 +9,9 @@
 #include "lha.h"
 
 int
-encode_lzhuf(infp, outfp, size, original_size_var, packed_size_var,
-         name, hdr_method)
-    FILE           *infp;
-    FILE           *outfp;
-    off_t          size;
-    off_t          *original_size_var;
-    off_t          *packed_size_var;
-    char           *name;
-    char           *hdr_method;
+encode_lzhuf(FILE *infp, FILE *outfp,
+             off_t size, off_t *original_size_var, off_t *packed_size_var,
+             char *name, char *hdr_method)
 {
     static int method = -1;
     unsigned int crc;

--- a/src/bitio.c
+++ b/src/bitio.c
@@ -12,8 +12,7 @@
 static unsigned char subbitbuf, bitcount;
 
 void
-fillbuf(n)          /* Shift bitbuf n bits left, read n bits */
-    unsigned char   n;
+fillbuf(unsigned char n)  /* Shift bitbuf n bits left, read n bits */
 {
     while (n > bitcount) {
         n -= bitcount;
@@ -36,8 +35,7 @@ fillbuf(n)          /* Shift bitbuf n bits left, read n bits */
 }
 
 unsigned short
-getbits(n)
-    unsigned char   n;
+getbits(unsigned char n)
 {
     unsigned short  x;
 
@@ -47,9 +45,7 @@ getbits(n)
 }
 
 void
-putcode(n, x)           /* Write leftmost n bits of x */
-    unsigned char   n;
-    unsigned short  x;
+putcode(unsigned char n, unsigned short x)  /* Write leftmost n bits of x */
 {
     while (n >= bitcount) {
         n -= bitcount;
@@ -71,9 +67,7 @@ putcode(n, x)           /* Write leftmost n bits of x */
 }
 
 void
-putbits(n, x)           /* Write rightmost n bits of x */
-    unsigned char   n;
-    unsigned short  x;
+putbits(unsigned char n, unsigned short x)  /* Write rightmost n bits of x */
 {
     x <<= USHRT_BIT - n;
     putcode(n, x);

--- a/src/crcio.c
+++ b/src/crcio.c
@@ -33,10 +33,7 @@ make_crctable( /* void */ )
 
 /* ------------------------------------------------------------------------ */
 unsigned int
-calccrc(crc, p, n)
-    unsigned int crc;
-    char  *p;
-    unsigned int    n;
+calccrc(unsigned int crc, char *p, unsigned int n)
 {
     while (n-- > 0)
         crc = UPDATE_CRC(crc, *p++);
@@ -45,11 +42,7 @@ calccrc(crc, p, n)
 
 /* ------------------------------------------------------------------------ */
 int
-fread_crc(crcp, p, n, fp)
-    unsigned int *crcp;
-    void *p;
-    int  n;
-    FILE *fp;
+fread_crc(unsigned int *crcp, void *p, int n, FILE *fp)
 {
     if (text_mode)
         n = fread_txt(p, n, fp);
@@ -65,11 +58,7 @@ fread_crc(crcp, p, n, fp)
 
 /* ------------------------------------------------------------------------ */
 void
-fwrite_crc(crcp, p, n, fp)
-    unsigned int *crcp;
-    void *p;
-    int  n;
-    FILE *fp;
+fwrite_crc(unsigned int *crcp, void *p, int n, FILE *fp)
 {
     *crcp = calccrc(*crcp, p, n);
 #ifdef NEED_INCREMENTAL_INDICATOR
@@ -103,9 +92,7 @@ init_code_cache( /* void */ )
 /* ------------------------------------------------------------------------ */
 #ifdef EUC
 int
-putc_euc(c, fd)
-    int             c;
-    FILE           *fd;
+putc_euc(int c, FILE *fd)
 {
     int             d;
 
@@ -141,10 +128,7 @@ putc_euc(c, fd)
 
 /* ------------------------------------------------------------------------ */
 int
-fwrite_txt(vp, n, fp)
-    void *vp;
-    int  n;
-    FILE *fp;
+fwrite_txt(void *vp, int n, FILE *fp)
 {
     unsigned char *p = vp;
 
@@ -165,10 +149,7 @@ fwrite_txt(vp, n, fp)
 
 /* ------------------------------------------------------------------------ */
 int
-fread_txt(vp, n, fp)
-    void *vp;
-    int  n;
-    FILE *fp;
+fread_txt(void *vp, int n, FILE *fp)
 {
     int             c;
     int             cnt = 0;

--- a/src/dhuf.c
+++ b/src/dhuf.c
@@ -83,9 +83,7 @@ decode_start_dyn( /* void */ )
 
 /* ------------------------------------------------------------------------ */
 static void
-reconst(start, end)
-    int             start;
-    int             end;
+reconst(int start, int end)
 {
     int             i, j, k, l, b;
     unsigned int    f, g;
@@ -139,8 +137,7 @@ reconst(start, end)
 
 /* ------------------------------------------------------------------------ */
 static int
-swap_inc(p)
-    int             p;
+swap_inc(int p)
 {
     int             b, q, r, s;
 
@@ -180,8 +177,7 @@ Adjust:
 
 /* ------------------------------------------------------------------------ */
 static void
-update_c(p)
-    int             p;
+update_c(int p)
 {
     int             q;
 
@@ -197,8 +193,7 @@ update_c(p)
 
 /* ------------------------------------------------------------------------ */
 static void
-update_p(p)
-    int             p;
+update_p(int p)
 {
     int             q;
 
@@ -216,8 +211,7 @@ update_p(p)
 
 /* ------------------------------------------------------------------------ */
 static void
-make_new_node(p)
-    int             p;
+make_new_node(int p)
 {
     int             q, r;
 
@@ -240,8 +234,7 @@ make_new_node(p)
 
 /* ------------------------------------------------------------------------ */
 static void
-encode_c_dyn(c)
-    unsigned int    c;
+encode_c_dyn(unsigned int c)
 {
     unsigned int    bits;
     int             p, d, cnt;
@@ -333,9 +326,7 @@ decode_p_dyn( /* void */ )
 /* ------------------------------------------------------------------------ */
 /* lh1 */
 void
-output_dyn(code, pos)
-    unsigned int    code;
-    unsigned int    pos;
+output_dyn(unsigned int code, unsigned int pos)
 {
     encode_c_dyn(code);
     if (code >= 0x100) {

--- a/src/extract.c
+++ b/src/extract.c
@@ -9,14 +9,9 @@
 #include "lha.h"
 
 int
-decode_lzhuf(infp, outfp, original_size, packed_size, name, method, read_sizep)
-    FILE           *infp;
-    FILE           *outfp;
-    off_t           original_size;
-    off_t           packed_size;
-    char           *name;
-    int             method;
-    off_t          *read_sizep;
+decode_lzhuf(FILE *infp, FILE *outfp,
+             off_t original_size, off_t packed_size,
+             char *name, int method, off_t *read_sizep)
 {
     unsigned int crc;
     struct interfacing interface;

--- a/src/header.c
+++ b/src/header.c
@@ -55,9 +55,7 @@ int default_system_kanji_code = NONE;
 #endif
 
 int
-calc_sum(p, len)
-    void *p;
-    int len;
+calc_sum(void *p, int len)
 {
     int sum = 0;
     unsigned char *pc = (unsigned char*)p;
@@ -68,8 +66,7 @@ calc_sum(p, len)
 }
 
 static void
-_skip_bytes(len)
-    int len;
+_skip_bytes(int len)
 {
     if (len < 0) {
       error("Invalid header: %d", len);
@@ -108,8 +105,7 @@ dump_get_byte()
 }
 
 static void
-dump_skip_bytes(len)
-    int len;
+dump_skip_bytes(int len)
 {
     if (len == 0) return;
     if (verbose_listing && verbose > 1) {
@@ -148,8 +144,7 @@ get_word()
 }
 
 static void
-put_word(v)
-    unsigned int    v;
+put_word(unsigned int v)
 {
     put_byte(v);
     put_byte(v >> 8);
@@ -231,9 +226,7 @@ put_longlongword(uint64_t v)
 #endif
 
 static int
-get_bytes(buf, len, size)
-    char *buf;
-    int len, size;
+get_bytes(char *buf, int len, int size)
 {
     int i;
 
@@ -272,9 +265,7 @@ get_bytes(buf, len, size)
 }
 
 static void
-put_bytes(buf, len)
-    char *buf;
-    int len;
+put_bytes(char *buf, int len)
 {
     int i;
     for (i = 0; i < len; i++)
@@ -282,16 +273,12 @@ put_bytes(buf, len)
 }
 
 void
-convert_filename(name, len, size,
-                 from_code, to_code,
-                 from_delim, to_delim,
-                 case_to)
-    char *name;
-    int len;                    /* length of name */
-    int size;                   /* size of name buffer */
-    int from_code, to_code, case_to;
-    char *from_delim, *to_delim;
-
+convert_filename(char *name,
+                 int len,       /* length of name */
+                 int size,      /* size of name buffer */
+                 int from_code, int to_code,
+                 char *from_delim, char *to_delim,
+                 int case_to)
 {
     int i;
 #ifdef MULTIBYTE_FILENAME
@@ -465,8 +452,7 @@ convert_filename(name, len, size,
  */
 
 static time_t
-generic_to_unix_stamp(t)
-    long t;
+generic_to_unix_stamp(long t)
 {
     struct tm tm;
 
@@ -488,8 +474,7 @@ generic_to_unix_stamp(t)
 }
 
 static long
-unix_to_generic_stamp(t)
-    time_t t;
+unix_to_generic_stamp(time_t t)
 {
     struct tm *tm = localtime(&t);
 
@@ -563,11 +548,7 @@ wintime_to_unix_stamp()
  */
 
 static ssize_t
-get_extended_header(fp, hdr, header_size, hcrc)
-    FILE *fp;
-    LzHeader *hdr;
-    size_t header_size;
-    unsigned int *hcrc;
+get_extended_header(FILE *fp, LzHeader *hdr, size_t header_size, unsigned int *hcrc)
 {
     char data[LZHEADER_STORAGE];
     int name_length;
@@ -815,10 +796,7 @@ get_extended_header(fp, hdr, header_size, hcrc)
  *
  */
 static int
-get_header_level0(fp, hdr, data)
-    FILE *fp;
-    LzHeader *hdr;
-    char *data;
+get_header_level0(FILE *fp, LzHeader *hdr, char *data)
 {
     size_t header_size;
     ssize_t remain_size;
@@ -938,10 +916,7 @@ get_header_level0(fp, hdr, data)
  *
  */
 static int
-get_header_level1(fp, hdr, data)
-    FILE *fp;
-    LzHeader *hdr;
-    char *data;
+get_header_level1(FILE *fp, LzHeader *hdr, char *data)
 {
     size_t header_size;
     ssize_t remain_size;
@@ -1040,10 +1015,7 @@ get_header_level1(fp, hdr, data)
  *
  */
 static int
-get_header_level2(fp, hdr, data)
-    FILE *fp;
-    LzHeader *hdr;
-    char *data;
+get_header_level2(FILE *fp, LzHeader *hdr, char *data)
 {
     size_t header_size;
     ssize_t remain_size;
@@ -1134,10 +1106,7 @@ get_header_level2(fp, hdr, data)
  *
  */
 static int
-get_header_level3(fp, hdr, data)
-    FILE *fp;
-    LzHeader *hdr;
-    char *data;
+get_header_level3(FILE *fp, LzHeader *hdr, char *data)
 {
     size_t header_size;
     ssize_t remain_size;
@@ -1197,9 +1166,7 @@ get_header_level3(fp, hdr, data)
 }
 
 boolean
-get_header(fp, hdr)
-    FILE *fp;
-    LzHeader *hdr;
+get_header(FILE *fp, LzHeader *hdr)
 {
     char data[LZHEADER_STORAGE];
 
@@ -1319,8 +1286,7 @@ get_header(fp, hdr)
 
 /* skip SFX header */
 int
-seek_lha_header(fp)
-    FILE *fp;
+seek_lha_header(FILE *fp)
 {
     unsigned char   buffer[64 * 1024]; /* max seek size */
     unsigned char  *p;
@@ -1461,10 +1427,7 @@ canon_path(char *newpath, char *path, size_t size)
 }
 
 void
-init_header(name, v_stat, hdr)
-    char           *name;
-    struct stat    *v_stat;
-    LzHeader       *hdr;
+init_header(char *name, struct stat *v_stat, LzHeader *hdr)
 {
     int             len;
 
@@ -1573,8 +1536,7 @@ init_header(name, v_stat, hdr)
 }
 
 static void
-write_unix_info(hdr)
-    LzHeader *hdr;
+write_unix_info(LzHeader *hdr)
 {
     /* UNIX specific informations */
 
@@ -1609,9 +1571,7 @@ write_unix_info(hdr)
 }
 
 static size_t
-write_header_level0(data, hdr, pathname)
-    LzHeader *hdr;
-    char *data, *pathname;
+write_header_level0(char *data, LzHeader *hdr, char *pathname)
 {
     int limit;
     int name_length;
@@ -1667,9 +1627,7 @@ write_header_level0(data, hdr, pathname)
 }
 
 static size_t
-write_header_level1(data, hdr, pathname)
-    LzHeader *hdr;
-    char *data, *pathname;
+write_header_level1(char *data, LzHeader *hdr, char *pathname)
 {
     int name_length, dir_length, limit;
     char *basename, *dirname;
@@ -1759,9 +1717,7 @@ write_header_level1(data, hdr, pathname)
 }
 
 static size_t
-write_header_level2(data, hdr, pathname)
-    LzHeader *hdr;
-    char *data, *pathname;
+write_header_level2(char *data, LzHeader *hdr, char *pathname)
 {
     int name_length, dir_length;
     char *basename, *dirname;
@@ -1851,9 +1807,7 @@ write_header_level2(data, hdr, pathname)
 }
 
 void
-write_header(fp, hdr)
-    FILE           *fp;
-    LzHeader       *hdr;
+write_header(FILE *fp, LzHeader *hdr)
 {
     size_t header_size;
     char data[LZHEADER_STORAGE];

--- a/src/header.c
+++ b/src/header.c
@@ -93,7 +93,7 @@ dump_get_byte()
     int c;
 
     if (verbose_listing && verbose > 1)
-        printf("%02d %2d: ", get_ptr - start_ptr, 1);
+        printf("%02ld %2d: ", get_ptr - start_ptr, 1);
     c = _get_byte();
     if (verbose_listing && verbose > 1) {
         if (isprint(c))
@@ -109,7 +109,7 @@ dump_skip_bytes(int len)
 {
     if (len == 0) return;
     if (verbose_listing && verbose > 1) {
-        printf("%02d %2d: ", get_ptr - start_ptr, len);
+        printf("%02ld %2d: ", get_ptr - start_ptr, len);
         if (len < 0) {
           error("Invalid header: %d", len);
           exit(1);
@@ -131,7 +131,7 @@ get_word()
 
 #if DUMP_HEADER
     if (verbose_listing && verbose > 1)
-        printf("%02d %2d: ", get_ptr - start_ptr, 2);
+        printf("%02ld %2d: ", get_ptr - start_ptr, 2);
 #endif
     b0 = _get_byte();
     b1 = _get_byte();
@@ -158,7 +158,7 @@ get_longword()
 
 #if DUMP_HEADER
     if (verbose_listing && verbose > 1)
-        printf("%02d %2d: ", get_ptr - start_ptr, 4);
+        printf("%02ld %2d: ", get_ptr - start_ptr, 4);
 #endif
     b0 = _get_byte();
     b1 = _get_byte();
@@ -190,7 +190,7 @@ get_longlongword()
 
 #if DUMP_HEADER
     if (verbose_listing && verbose > 1)
-        printf("%02d %2d: ", get_ptr - start_ptr, 4);
+        printf("%02ld %2d: ", get_ptr - start_ptr, 4);
 #endif
     b0 = _get_byte();
     b1 = _get_byte();
@@ -232,7 +232,7 @@ get_bytes(char *buf, int len, int size)
 
 #if DUMP_HEADER
     if (verbose_listing && verbose > 1)
-        printf("%02d %2d: \"", get_ptr - start_ptr, len);
+        printf("%02ld %2d: \"", get_ptr - start_ptr, len);
     if (len < 0) {
       error("Invalid header: %d", len);
       exit(1);

--- a/src/huf.c
+++ b/src/huf.c
@@ -95,7 +95,7 @@ write_pt_len(short n, short nbit, short i_special)
             putbits(3, k);
         else
             /* k=7 -> 1110  k=8 -> 11110  k=9 -> 111110 ... */
-            putbits(k - 3, USHRT_MAX << 1);
+            putbits(k - 3, (short)(USHRT_MAX << 1));
         if (i == i_special) {
             while (i < 6 && pt_len[i] == 0)
                 i++;

--- a/src/huf.c
+++ b/src/huf.c
@@ -81,10 +81,7 @@ count_t_freq(/*void*/)
 
 /* ------------------------------------------------------------------------ */
 static void
-write_pt_len(n, nbit, i_special)
-    short           n;
-    short           nbit;
-    short           i_special;
+write_pt_len(short n, short nbit, short i_special)
 {
     short           i, k;
 
@@ -151,16 +148,14 @@ write_c_len(/*void*/)
 
 /* ------------------------------------------------------------------------ */
 static void
-encode_c(c)
-    short           c;
+encode_c(short c)
 {
     putcode(c_len[c], c_code[c]);
 }
 
 /* ------------------------------------------------------------------------ */
 static void
-encode_p(p)
-    unsigned short  p;
+encode_p(unsigned short p)
 {
     unsigned short  c, q;
 
@@ -234,9 +229,7 @@ send_block( /* void */ )
 /* ------------------------------------------------------------------------ */
 /* lh4, 5, 6, 7 */
 void
-output_st1(c, p)
-    unsigned int  c;
-    unsigned int  p;
+output_st1(unsigned int c, unsigned int p)
 {
     static unsigned short cpos;
 
@@ -321,10 +314,7 @@ encode_end_st1( /* void */ )
 /*                              decoding                                    */
 /* ------------------------------------------------------------------------ */
 static void
-read_pt_len(nn, nbit, i_special)
-    short           nn;
-    short           nbit;
-    short           i_special;
+read_pt_len(short nn, short nbit, short i_special)
 {
     int           i, c, n;
 

--- a/src/indicator.c
+++ b/src/indicator.c
@@ -38,11 +38,7 @@ carriage_return()
 }
 
 void
-start_indicator(name, size, msg, def_indicator_threshold)
-    char           *name;
-    off_t          size;
-    char           *msg;
-    long            def_indicator_threshold;
+start_indicator(char *name, off_t size, char *msg, long def_indicator_threshold)
 {
 #ifdef NEED_INCREMENTAL_INDICATOR
     long i;
@@ -89,8 +85,7 @@ start_indicator(name, size, msg, def_indicator_threshold)
 
 #ifdef NEED_INCREMENTAL_INDICATOR
 void
-put_indicator(count)
-    long int        count;
+put_indicator(long int count)
 {
     reading_size += count;
     if (!quiet && indicator_threshold) {
@@ -104,10 +99,7 @@ put_indicator(count)
 #endif
 
 void
-finish_indicator2(name, msg, pcnt)
-    char           *name;
-    char           *msg;
-    int             pcnt;
+finish_indicator2(char *name, char *msg, int pcnt)
 {
     if (quiet)
         return;
@@ -124,9 +116,7 @@ finish_indicator2(name, msg, pcnt)
 }
 
 void
-finish_indicator(name, msg)
-    char           *name;
-    char           *msg;
+finish_indicator(char *name, char *msg)
 {
     if (quiet)
         return;

--- a/src/lhadd.c
+++ b/src/lhadd.c
@@ -16,9 +16,7 @@ static char    *new_archive_name;
 static time_t most_recent;      /* for time-stamp archiving */
 
 static void
-copy_old_one(oafp, nafp, hdr)
-    FILE           *oafp, *nafp;
-    LzHeader       *hdr;
+copy_old_one(FILE *oafp, FILE *nafp, LzHeader *hdr)
 {
     if (noexec) {
         fseeko(oafp, hdr->header_size + hdr->packed_size, SEEK_CUR);
@@ -37,9 +35,7 @@ copy_old_one(oafp, nafp, hdr)
 }
 
 static void
-add_one(fp, nafp, hdr)
-    FILE           *fp, *nafp;
-    LzHeader       *hdr;
+add_one(FILE *fp, FILE *nafp, LzHeader *hdr)
 {
     off_t header_pos, next_pos, org_pos, data_pos;
     off_t v_original_size, v_packed_size;
@@ -102,9 +98,7 @@ add_one(fp, nafp, hdr)
 }
 
 FILE           *
-append_it(name, oafp, nafp)
-    char           *name;
-    FILE           *oafp, *nafp;
+append_it(char *name, FILE *oafp, FILE *nafp)
 {
     LzHeader        ahdr, hdr;
     FILE           *fp;
@@ -213,8 +207,7 @@ append_it(name, oafp, nafp)
 
 /* ------------------------------------------------------------------------ */
 static void
-find_update_files(oafp)
-    FILE           *oafp;   /* old archive */
+find_update_files(FILE *oafp)  /* oafp: old archive */
 {
     char            name[FILENAME_LENGTH];
     struct string_pool sp;
@@ -249,8 +242,7 @@ find_update_files(oafp)
 
 /* ------------------------------------------------------------------------ */
 static void
-delete(oafp, nafp)
-    FILE           *oafp, *nafp;
+delete(FILE *oafp, FILE *nafp)
 {
     LzHeader ahdr;
     off_t old_header_pos;
@@ -345,8 +337,7 @@ report_archive_name_if_different()
 
 /* ------------------------------------------------------------------------ */
 void
-temporary_to_new_archive_file(new_archive_size)
-    off_t new_archive_size;
+temporary_to_new_archive_file(off_t new_archive_size)
 {
     FILE *oafp, *nafp;
 
@@ -412,8 +403,7 @@ set_archive_file_mode()
 /*                          REMOVE FILE/DIRECTORY                           */
 /* ------------------------------------------------------------------------ */
 static void
-remove_one(name)
-    char           *name;
+remove_one(char *name)
 {
     struct stat     stbuf;
     int             filec;
@@ -459,9 +449,7 @@ remove_one(name)
 }
 
 static void
-remove_files(filec, filev)
-    int             filec;
-    char          **filev;
+remove_files(int filec, char **filev)
 {
     int             i;
 

--- a/src/lharc.c
+++ b/src/lharc.c
@@ -630,9 +630,7 @@ parse_option(int argc, char **argv)
 
 /* ------------------------------------------------------------------------ */
 int
-main(argc, argv)
-    int             argc;
-    char           *argv[];
+main(int argc, char *argv[])
 {
     char           *p;
 
@@ -858,8 +856,7 @@ cleanup()
 }
 
 RETSIGTYPE
-interrupt(signo)
-    int signo;
+interrupt(int signo)
 {
     message("Interrupted");
 
@@ -876,13 +873,14 @@ interrupt(signo)
 /*                                                                          */
 /* ------------------------------------------------------------------------ */
 static int
-sort_by_ascii(a, b)
-    char          **a, **b;
+sort_by_ascii(const void *a, const void *b)
 {
+    char **pa = (char **)a;
+    char **pb = (char **)b;
     register char  *p, *q;
     register int    c1, c2;
 
-    p = *a, q = *b;
+    p = *pa, q = *pb;
     if (generic_format) {
         do {
             c1 = *(unsigned char *) p++;
@@ -914,8 +912,7 @@ sort_files()
 
 /* ------------------------------------------------------------------------ */
 void *
-xmalloc(size)
-    size_t size;
+xmalloc(size_t size)
 {
     void *p = malloc(size);
     if (!p)
@@ -925,9 +922,7 @@ xmalloc(size)
 
 /* ------------------------------------------------------------------------ */
 void *
-xrealloc(old, size)
-    void *old;
-    size_t size;
+xrealloc(void *old, size_t size)
 {
     void *p = (char *) realloc(old, size);
     if (!p)
@@ -936,8 +931,7 @@ xrealloc(old, size)
 }
 
 char *
-xstrdup(str)
-    char *str;
+xstrdup(char *str)
 {
     int len = strlen(str);
     char *p = (char *)xmalloc(len + 1);
@@ -965,8 +959,7 @@ xstrdup(str)
 
 /* ------------------------------------------------------------------------ */
 void
-init_sp(sp)
-    struct string_pool *sp;
+init_sp(struct string_pool *sp)
 {
     sp->size = 1024 - 8;    /* any ( >=0 ) */
     sp->used = 0;
@@ -976,10 +969,9 @@ init_sp(sp)
 
 /* ------------------------------------------------------------------------ */
 void
-add_sp(sp, name, len)
-    struct string_pool *sp;
-    char           *name;   /* stored '\0' at tail */
-    int             len;    /* include '\0' */
+add_sp(struct string_pool *sp,
+       char *name,          /* stored '\0' at tail */
+       int len)             /* include '\0' */
 {
     while (sp->used + len > sp->size) {
         sp->size *= 2;
@@ -992,10 +984,7 @@ add_sp(sp, name, len)
 
 /* ------------------------------------------------------------------------ */
 void
-finish_sp(sp, v_count, v_vector)
-    register struct string_pool *sp;
-    int            *v_count;
-    char         ***v_vector;
+finish_sp(register struct string_pool *sp, int *v_count, char ***v_vector)
 {
     int             i;
     register char  *p;
@@ -1015,8 +1004,7 @@ finish_sp(sp, v_count, v_vector)
 
 /* ------------------------------------------------------------------------ */
 void
-free_sp(vector)
-    char          **vector;
+free_sp(char **vector)
 {
     vector--;
     free(*vector);      /* free string pool */
@@ -1028,8 +1016,7 @@ free_sp(vector)
 /*                          READ DIRECTORY FILES                            */
 /* ------------------------------------------------------------------------ */
 static          boolean
-include_path_p(path, name)
-    char           *path, *name;
+include_path_p(char *path, char *name)
 {
     char           *n = name;
     while (*path)
@@ -1040,9 +1027,7 @@ include_path_p(path, name)
 
 /* ------------------------------------------------------------------------ */
 void
-cleaning_files(v_filec, v_filev)
-    int            *v_filec;
-    char         ***v_filev;
+cleaning_files(int *v_filec, char ***v_filev)
 {
     char           *flags;
     struct stat     stbuf;
@@ -1123,10 +1108,7 @@ cleaning_files(v_filec, v_filev)
 
 /* ------------------------------------------------------------------------ */
 boolean
-find_files(name, v_filec, v_filev)
-    char           *name;
-    int            *v_filec;
-    char         ***v_filev;
+find_files(char *name, int *v_filec, char ***v_filev)
 {
     struct string_pool sp;
     char            newname[FILENAME_LENGTH];
@@ -1209,9 +1191,7 @@ find_files(name, v_filec, v_filev)
 
 /* ------------------------------------------------------------------------ */
 void
-free_files(filec, filev)
-    int             filec;
-    char          **filev;
+free_files(int filec, char **filev)
 {
     free_sp(filev);
 }
@@ -1277,10 +1257,7 @@ build_temporary_name()
 
 /* ------------------------------------------------------------------------ */
 static void
-modify_filename_extention(buffer, ext, size)
-    char           *buffer;
-    char           *ext;
-    size_t size;
+modify_filename_extention(char *buffer, char *ext, size_t size)
 {
     register char  *p, *dot;
 
@@ -1300,10 +1277,7 @@ modify_filename_extention(buffer, ext, size)
 /* ------------------------------------------------------------------------ */
 /* build backup file name */
 void
-build_backup_name(buffer, original, size)
-    char           *buffer;
-    char           *original;
-    size_t size;
+build_backup_name(char *buffer, char *original, size_t size)
 {
     str_safe_copy(buffer, original, size);
     modify_filename_extention(buffer, BACKUPNAME_EXTENTION, size);    /* ".bak" */
@@ -1311,10 +1285,7 @@ build_backup_name(buffer, original, size)
 
 /* ------------------------------------------------------------------------ */
 void
-build_standard_archive_name(buffer, original, size)
-    char           *buffer;
-    char           *original;
-    size_t size;
+build_standard_archive_name(char *buffer, char *original, size_t size)
 {
     str_safe_copy(buffer, original, size);
     modify_filename_extention(buffer, ARCHIVENAME_EXTENTION, size);   /* ".lzh" */
@@ -1324,8 +1295,7 @@ build_standard_archive_name(buffer, original, size)
 /*                                                                          */
 /* ------------------------------------------------------------------------ */
 boolean
-need_file(name)
-    char           *name;
+need_file(char *name)
 {
     int             i;
 
@@ -1341,8 +1311,7 @@ need_file(name)
 }
 
 FILE           *
-xfopen(name, mode)
-    char           *name, *mode;
+xfopen(char *name, char *mode)
 {
     FILE           *fp;
 
@@ -1356,9 +1325,7 @@ xfopen(name, mode)
 /*                                                                          */
 /* ------------------------------------------------------------------------ */
 static          boolean
-open_old_archive_1(name, v_fp)
-    char           *name;
-    FILE          **v_fp;
+open_old_archive_1(char *name, FILE **v_fp)
 {
     FILE           *fp;
     struct stat     stbuf;
@@ -1453,8 +1420,7 @@ ret:
 
 /* ------------------------------------------------------------------------ */
 int
-inquire(msg, name, selective)
-    char           *msg, *name, *selective;
+inquire(char *msg, char *name, char *selective)
 {
     char            buffer[1024];
     char           *p;
@@ -1478,8 +1444,7 @@ inquire(msg, name, selective)
 
 /* ------------------------------------------------------------------------ */
 void
-write_archive_tail(nafp)
-    FILE           *nafp;
+write_archive_tail(FILE *nafp)
 {
     putc(0x00, nafp);
 }
@@ -1488,8 +1453,7 @@ write_archive_tail(nafp)
 #undef exit
 
 void
-lha_exit(status)
-    int status;
+lha_exit(int status)
 {
     cleanup();
     exit(status);

--- a/src/lhdir.c
+++ b/src/lhdir.c
@@ -36,8 +36,7 @@
 
 /* ------------------------------------------------------------------------ */
 DIR            *
-opendir(name)
-    char           *name;
+opendir(char *name)
 {
     register DIR   *dirp;
     register int    fd;
@@ -58,8 +57,7 @@ opendir(name)
 
 /* ------------------------------------------------------------------------ */
 struct direct  *
-readdir(dirp)
-    register DIR   *dirp;
+readdir(register DIR *dirp)
 {
     static struct direct lhdir;
     register struct old_direct *dp;
@@ -90,8 +88,7 @@ readdir(dirp)
 }
 
 /* ------------------------------------------------------------------------ */
-closedir(dirp)
-    DIR            *dirp;
+closedir(DIR *dirp)
 {
     close(dirp->dd_fd);
     free(dirp);

--- a/src/lhext.c
+++ b/src/lhext.c
@@ -127,7 +127,7 @@ make_name_with_pathcheck(char *name, size_t namesz, const char *q)
 
 /* ------------------------------------------------------------------------ */
 static          boolean
-make_parent_path(char *name)
+make_parent_path(const char *name)
 {
     char            path[FILENAME_LENGTH];
     struct stat     stbuf;

--- a/src/lhext.c
+++ b/src/lhext.c
@@ -35,8 +35,7 @@ static boolean decode_macbinary(FILE *ofp, off_t size, const char *outPath);
 
 /* ------------------------------------------------------------------------ */
 static          boolean
-inquire_extract(name)
-    char           *name;
+inquire_extract(char *name)
 {
     struct stat     stbuf;
 
@@ -128,8 +127,7 @@ make_name_with_pathcheck(char *name, size_t namesz, const char *q)
 
 /* ------------------------------------------------------------------------ */
 static          boolean
-make_parent_path(name)
-    char           *name;
+make_parent_path(char *name)
 {
     char            path[FILENAME_LENGTH];
     struct stat     stbuf;
@@ -184,8 +182,7 @@ make_parent_path(name)
 
 /* ------------------------------------------------------------------------ */
 static FILE    *
-open_with_make_path(name)
-    char           *name;
+open_with_make_path(char *name)
 {
     FILE           *fp;
 
@@ -199,9 +196,7 @@ open_with_make_path(name)
 
 /* ------------------------------------------------------------------------ */
 static int
-symlink_with_make_path(realname, name)
-    const char     *realname;
-    const char     *name;
+symlink_with_make_path(const char *realname, const char *name)
 {
     int l_code;
 
@@ -216,9 +211,7 @@ symlink_with_make_path(realname, name)
 
 /* ------------------------------------------------------------------------ */
 static void
-adjust_info(name, hdr)
-    char           *name;
-    LzHeader       *hdr;
+adjust_info(char *name, LzHeader *hdr)
 {
 #if HAVE_UTIMES
     struct timeval timevals[2];
@@ -283,9 +276,8 @@ adjust_info(name, hdr)
 
 /* ------------------------------------------------------------------------ */
 static off_t
-extract_one(afp, hdr)
-    FILE           *afp;    /* archive file */
-    LzHeader       *hdr;
+extract_one(FILE *afp,  /* archive file */
+            LzHeader *hdr)
 {
     FILE           *fp; /* output file */
 #if HAVE_LIBAPPLEFILE
@@ -753,10 +745,7 @@ static void adjust_dirinfo()
 
 #if HAVE_LIBAPPLEFILE
 static boolean
-decode_macbinary(ofp, size, outPath)
-    FILE *ofp;
-    off_t size;
-    const char *outPath;
+decode_macbinary(FILE *ofp, off_t size, const char *outPath)
 {
     af_file_t *afp = NULL;
     FILE *ifp = NULL;

--- a/src/lhlist.c
+++ b/src/lhlist.c
@@ -41,8 +41,7 @@ print_size(off_t packed_size, off_t original_size)
 /* ------------------------------------------------------------------------ */
 /* need 12 or 17 (when verbose_listing is TRUE) column spaces */
 static void
-print_stamp(t)
-    time_t t;
+print_stamp(time_t t)
 {
     static unsigned int threshold;
     static char     t_month[12 * 3 + 1] = "JanFebMarAprMayJunJulAugSepOctNovDec";
@@ -121,8 +120,7 @@ list_header()
 
 /* ------------------------------------------------------------------------ */
 static void
-list_one(hdr)
-    register LzHeader *hdr;
+list_one(register LzHeader *hdr)
 {
     register int    mode = 0;
     register char  *p;
@@ -278,9 +276,7 @@ list_one(hdr)
 
 /* ------------------------------------------------------------------------ */
 static void
-list_tailer(list_files, packed_size_total, original_size_total)
-    int list_files;
-    off_t packed_size_total, original_size_total;
+list_tailer(int list_files, off_t packed_size_total, off_t original_size_total)
 {
     struct stat     stbuf;
 

--- a/src/maketbl.c
+++ b/src/maketbl.c
@@ -9,11 +9,7 @@
 #include "lha.h"
 
 void
-make_table(nchar, bitlen, tablebits, table)
-    short           nchar;
-    unsigned char   bitlen[];
-    short           tablebits;
-    unsigned short  table[];
+make_table(short nchar, unsigned char bitlen[], short tablebits, unsigned short table[])
 {
     unsigned short  count[17];  /* count of bitlen */
     unsigned short  weight[17]; /* 0x10000ul >> bitlen */

--- a/src/maketree.c
+++ b/src/maketree.c
@@ -9,11 +9,9 @@
 #include "lha.h"
 
 static void
-make_code(nchar, bitlen, code, leaf_num)
-    int            nchar;
-    unsigned char  *bitlen;
-    unsigned short *code;       /* table */
-    unsigned short *leaf_num;
+make_code(int nchar, unsigned char *bitlen,
+          unsigned short *code,  /* table */
+          unsigned short *leaf_num)
 {
     unsigned short  weight[17]; /* 0x10000ul >> bitlen */
     unsigned short  start[17];  /* start code */
@@ -35,11 +33,7 @@ make_code(nchar, bitlen, code, leaf_num)
 }
 
 static void
-count_leaf(node, nchar, leaf_num, depth) /* call with node = root */
-    int node;
-    int nchar;
-    unsigned short leaf_num[];
-    int depth;
+count_leaf(int node, int nchar, unsigned short leaf_num[], int depth) /* call with node = root */
 {
     if (node < nchar)
         leaf_num[depth < 16 ? depth : 16]++;
@@ -50,11 +44,9 @@ count_leaf(node, nchar, leaf_num, depth) /* call with node = root */
 }
 
 static void
-make_len(nchar, bitlen, sort, leaf_num)
-    int nchar;
-    unsigned char *bitlen;
-    unsigned short *sort;       /* sorted characters */
-    unsigned short *leaf_num;
+make_len(int nchar, unsigned char *bitlen,
+         unsigned short *sort,  /* sorted characters */
+         unsigned short *leaf_num)
 {
     int i, k;
     unsigned int cum;
@@ -91,11 +83,7 @@ make_len(nchar, bitlen, sort, leaf_num)
 
 /* priority queue; send i-th entry down heap */
 static void
-downheap(i, heap, heapsize, freq)
-    int i;
-    short *heap;
-    size_t heapsize;
-    unsigned short *freq;
+downheap(int i, short *heap, size_t heapsize, unsigned short *freq)
 {
     short j, k;
 
@@ -113,11 +101,7 @@ downheap(i, heap, heapsize, freq)
 
 /* make tree, calculate bitlen[], return root */
 short
-make_tree(nchar, freq, bitlen, code)
-    int             nchar;
-    unsigned short  *freq;
-    unsigned char   *bitlen;
-    unsigned short  *code;
+make_tree(int nchar, unsigned short *freq, unsigned char *bitlen, unsigned short *code)
 {
     short i, j, avail, root;
     unsigned short *sort;

--- a/src/patmatch.c
+++ b/src/patmatch.c
@@ -19,7 +19,7 @@ patmatch(register char *p,  /* pattern */
 {
     char            pc; /* a single character from pattern */
 
-    while (pc = ((f && islower(*p)) ? toupper(*p++) : *p++)) {
+    while ((pc = ((f && islower(*p)) ? toupper(*p++) : *p++))) {
         if (pc == '*') {
             do {    /* look for match till s exhausted */
                 if (patmatch(p, s, f))

--- a/src/patmatch.c
+++ b/src/patmatch.c
@@ -13,10 +13,9 @@
  * Returns true if string s matches pattern p.
  */
 int
-patmatch(p, s, f)
-    register char  *p;  /* pattern */
-    register char  *s;  /* string to match */
-    int             f;  /* flag for case force */
+patmatch(register char *p,  /* pattern */
+         register char *s,  /* string to match */
+         int f)             /* flag for case force */
 {
     char            pc; /* a single character from pattern */
 

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -3,27 +3,27 @@
 /* append.c */
 int encode_lzhuf(FILE *infp, FILE *outfp, off_t size, off_t *original_size_var, off_t *packed_size_var, char *name, char *hdr_method);
 /* bitio.c */
-void fillbuf(int n);
-unsigned short getbits(int n);
-void putcode(int n, int x);
-void putbits(int n, int x);
-void init_getbits(void);
-void init_putbits(void);
+void fillbuf(unsigned char n);
+unsigned short getbits(unsigned char n);
+void putcode(unsigned char n, unsigned short x);
+void putbits(unsigned char n, unsigned short x);
+void init_getbits( /* void */ );
+void init_putbits( /* void */ );
 /* crcio.c */
-void make_crctable(void);
+void make_crctable( /* void */ );
 unsigned int calccrc(unsigned int crc, char *p, unsigned int n);
 int fread_crc(unsigned int *crcp, void *p, int n, FILE *fp);
 void fwrite_crc(unsigned int *crcp, void *p, int n, FILE *fp);
-void init_code_cache(void);
+void init_code_cache( /* void */ );
 int fwrite_txt(void *vp, int n, FILE *fp);
 int fread_txt(void *vp, int n, FILE *fp);
 /* dhuf.c */
-void start_c_dyn(void);
-void decode_start_dyn(void);
-unsigned short decode_c_dyn(void);
-unsigned short decode_p_dyn(void);
+void start_c_dyn( /* void */ );
+void decode_start_dyn( /* void */ );
+unsigned short decode_c_dyn( /* void */ );
+unsigned short decode_p_dyn( /* void */ );
 void output_dyn(unsigned int code, unsigned int pos);
-void encode_end_dyn(void);
+void encode_end_dyn( /* void */ );
 /* extract.c */
 int decode_lzhuf(FILE *infp, FILE *outfp, off_t original_size, off_t packed_size, char *name, int method, off_t *read_sizep);
 /* header.c */
@@ -39,37 +39,37 @@ int cap_to_sjis(char *dst, const char *src, size_t dstsize);
 int sjis_to_cap(char *dst, const char *src, size_t dstsize);
 /* huf.c */
 void output_st1(unsigned int c, unsigned int p);
-unsigned char *alloc_buf(void);
-void encode_start_st1(void);
-void encode_end_st1(void);
-unsigned short decode_c_st1(void);
-unsigned short decode_p_st1(void);
-void decode_start_st1(void);
+unsigned char *alloc_buf( /* void */ );
+void encode_start_st1( /* void */ );
+void encode_end_st1( /* void */ );
+unsigned short decode_c_st1( /* void */ );
+unsigned short decode_p_st1( /* void */ );
+void decode_start_st1( /* void */ );
 /* indicator.c */
 void start_indicator(char *name, off_t size, char *msg, long def_indicator_threshold);
 void put_indicator(long int count);
 void finish_indicator2(char *name, char *msg, int pcnt);
 void finish_indicator(char *name, char *msg);
 /* larc.c */
-unsigned short decode_c_lzs(void);
-unsigned short decode_p_lzs(void);
-void decode_start_lzs(void);
-unsigned short decode_c_lz5(void);
-unsigned short decode_p_lz5(void);
-void decode_start_lz5(void);
+unsigned short decode_c_lzs( /* void */ );
+unsigned short decode_p_lzs( /* void */ );
+void decode_start_lzs( /* void */ );
+unsigned short decode_c_lz5( /* void */ );
+unsigned short decode_p_lz5( /* void */ );
+void decode_start_lz5( /* void */ );
 /* lhadd.c */
 FILE *append_it(char *name, FILE *oafp, FILE *nafp);
-FILE *build_temporary_file(void);
+FILE *build_temporary_file( /* void */ );
 void temporary_to_new_archive_file(off_t new_archive_size);
-void cmd_add(void);
-void cmd_delete(void);
+void cmd_add( /* void */ );
+void cmd_delete( /* void */ );
 /* lharc.c */
 int main(int argc, char *argv[]);
 void message(char *fmt, ...);
 void warning(char *fmt, ...);
 void error(char *fmt, ...);
 void fatal_error(char *fmt, ...);
-void cleanup(void);
+void cleanup( /* void */ );
 RETSIGTYPE interrupt(int signo);
 void *xmalloc(size_t size);
 void *xrealloc(void *old, size_t size);
@@ -81,33 +81,33 @@ void free_sp(char **vector);
 void cleaning_files(int *v_filec, char ***v_filev);
 boolean find_files(char *name, int *v_filec, char ***v_filev);
 void free_files(int filec, char **filev);
-int build_temporary_name(void);
+int build_temporary_name( /* void */ );
 void build_backup_name(char *buffer, char *original, size_t size);
 void build_standard_archive_name(char *buffer, char *original, size_t size);
 boolean need_file(char *name);
 FILE *xfopen(char *name, char *mode);
-FILE *open_old_archive(void);
+FILE *open_old_archive( /* void */ );
 int inquire(char *msg, char *name, char *selective);
 void write_archive_tail(FILE *nafp);
 void lha_exit(int status);
 /* lhext.c */
-void cmd_extract(void);
+void cmd_extract( /* void */ );
 int is_directory_traversal(char *path);
 /* lhlist.c */
-void cmd_list(void);
+void cmd_list( /* void */ );
 /* maketbl.c */
-void make_table(int nchar, unsigned char bitlen[], int tablebits, unsigned short table[]);
+void make_table(short nchar, unsigned char bitlen[], short tablebits, unsigned short table[]);
 /* maketree.c */
 short make_tree(int nchar, unsigned short *freq, unsigned char *bitlen, unsigned short *code);
 /* patmatch.c */
 int patmatch(register char *p, register char *s, int f);
 /* shuf.c */
-void decode_start_st0(void);
-void encode_p_st0(int j);
-void encode_start_fix(void);
-void decode_start_fix(void);
-unsigned short decode_c_st0(void);
-unsigned short decode_p_st0(void);
+void decode_start_st0( /* void */ );
+void encode_p_st0(unsigned short j);
+void encode_start_fix( /* void */ );
+void decode_start_fix( /* void */ );
+unsigned short decode_c_st0( /* void */ );
+unsigned short decode_p_st0( /* void */ );
 /* slide.c */
 int encode_alloc(int method);
 unsigned int encode(struct interfacing *interface);
@@ -123,16 +123,16 @@ char *xmemchr(const char *s, int c, size_t n);
 char *xmemrchr(const char *s, int c, size_t n);
 int str_safe_copy(char *dst, const char *src, int dstsz);
 /* pm2.c */
-void decode_start_pm2(void);
-unsigned short decode_c_pm2(void);
-unsigned short decode_p_pm2(void);
+void decode_start_pm2( /* void */ );
+unsigned short decode_c_pm2( /* void */ );
+unsigned short decode_p_pm2( /* void */ );
 /* pm2tree.c */
-void maketree1(void);
+void maketree1( /* void */ );
 void maketree2(int tree2bound);
-int tree1_get(void);
-int tree2_get(void);
+int tree1_get( /* void */ );
+int tree2_get( /* void */ );
 /* pm2hist.c */
-void hist_init(void);
+void hist_init( /* void */ );
 unsigned char hist_lookup(int n);
 void hist_update(unsigned char data);
 /* support_utf8.c */

--- a/src/shuf.c
+++ b/src/shuf.c
@@ -34,8 +34,7 @@ decode_start_st0( /*void*/ )
 
 /* ------------------------------------------------------------------------ */
 void
-encode_p_st0(j)
-    unsigned short  j;
+encode_p_st0(unsigned short j)
 {
     unsigned short  i;
 
@@ -46,8 +45,7 @@ encode_p_st0(j)
 
 /* ------------------------------------------------------------------------ */
 static void
-ready_made(method)
-    int             method;
+ready_made(int method)
 {
     int             i, j;
     unsigned int    code, weight;

--- a/src/slide.c
+++ b/src/slide.c
@@ -103,8 +103,7 @@ struct matchdata {
 };
 
 int
-encode_alloc(method)
-    int method;
+encode_alloc(int method)
 {
     switch (method) {
     case LZHUFF1_METHOD_NUM:
@@ -159,9 +158,7 @@ init_slide()
 
 /* update dictionary */
 static void
-update_dict(pos, crc)
-    unsigned int *pos;
-    unsigned int *crc;
+update_dict(unsigned int *pos, unsigned int *crc)
 {
     unsigned int i, j;
     long n;
@@ -186,21 +183,16 @@ update_dict(pos, crc)
 
 /* associate position with token */
 static void
-insert_hash(token, pos)
-    unsigned int token;
-    unsigned int pos;
+insert_hash(unsigned int token, unsigned int pos)
 {
     prev[pos & (dicsiz - 1)] = hash[token].pos; /* chain the previous pos. */
     hash[token].pos = pos;
 }
 
 static void
-search_dict_1(token, pos, off, max, m)
-    unsigned int token;
-    unsigned int pos;
-    unsigned int off;
-    unsigned int max;           /* max. length of matching string */
-    struct matchdata *m;
+search_dict_1(unsigned int token, unsigned int pos, unsigned int off,
+              unsigned int max,  /* max. length of matching string */
+              struct matchdata *m)
 {
     unsigned int chain = 0;
     unsigned int scan_pos = hash[token].pos;
@@ -246,11 +238,10 @@ search_dict_1(token, pos, off, max, m)
 
 /* search the longest token matching to current token */
 static void
-search_dict(token, pos, min, m)
-    unsigned int token;         /* search token */
-    unsigned int pos;           /* position of token */
-    int min;                    /* min. length of matching string */
-    struct matchdata *m;
+search_dict(unsigned int token,  /* search token */
+            unsigned int pos,    /* position of token */
+            int min,             /* min. length of matching string */
+            struct matchdata *m)
 {
     unsigned int off, tok, max;
 
@@ -283,10 +274,7 @@ search_dict(token, pos, min, m)
 
 /* slide dictionary */
 static void
-next_token(token, pos, crc)
-    unsigned int *token;
-    unsigned int *pos;
-    unsigned int *crc;
+next_token(unsigned int *token, unsigned int *pos, unsigned int *crc)
 {
     remainder--;
     if (++*pos >= txtsiz - maxmatch) {
@@ -299,8 +287,7 @@ next_token(token, pos, crc)
 }
 
 unsigned int
-encode(interface)
-    struct interfacing *interface;
+encode(struct interfacing *interface)
 {
     unsigned int token, pos, crc;
     off_t count;
@@ -389,8 +376,7 @@ encode(interface)
 }
 
 unsigned int
-decode(interface)
-    struct interfacing *interface;
+decode(struct interfacing *interface)
 {
     unsigned int i, c;
     unsigned int dicsiz1, adjust;

--- a/src/util.c
+++ b/src/util.c
@@ -16,12 +16,9 @@
 #include <errno.h>
 
 off_t
-copyfile(f1, f2, size, text_flg, crcp)  /* return: size of source file */
-    FILE *f1;
-    FILE *f2;
-    off_t size;
-    int text_flg;               /* 0: binary, 1: read text, 2: write text */
-    unsigned int *crcp;
+copyfile(FILE *f1, FILE *f2, off_t size,
+         int text_flg,        /* 0: binary, 1: read text, 2: write text */
+         unsigned int *crcp)  /* return: size of source file */
 {
     unsigned short  xsize;
     char *buf;
@@ -84,11 +81,7 @@ copyfile(f1, f2, size, text_flg, crcp)  /* return: size of source file */
 }
 
 int
-encode_stored_crc(ifp, ofp, size, original_size_var, write_size_var)
-    FILE *ifp, *ofp;
-    off_t size;
-    off_t *original_size_var;
-    off_t *write_size_var;
+encode_stored_crc(FILE *ifp, FILE *ofp, off_t size, off_t *original_size_var, off_t *write_size_var)
 {
     int save_quiet;
     unsigned int crc;
@@ -103,8 +96,7 @@ encode_stored_crc(ifp, ofp, size, original_size_var, write_size_var)
 
 /* If TRUE, archive file name is msdos SFX file name. */
 boolean
-archive_is_msdos_sfx1(name)
-    char *name;
+archive_is_msdos_sfx1(char *name)
 {
     int len = strlen(name);
 
@@ -125,8 +117,7 @@ archive_is_msdos_sfx1(name)
  */
 #ifndef HAVE_STRDUP
 char *
-strdup(buf)
-    const char *buf;
+strdup(const char *buf)
 {
     char *p;
 
@@ -142,9 +133,7 @@ strdup(buf)
  */
 #ifndef HAVE_MEMMOVE
 void *
-memmove(dst, src, cnt)
-    register char *dst, *src;
-    register int cnt;
+memmove(register char *dst, register char *src, register int cnt)
 {
     if (dst == src)
         return dst;
@@ -168,8 +157,7 @@ memmove(dst, src, cnt)
 #include <ctype.h>
 
 int
-strcasecmp(p1, p2)
-    const char *p1, *p2;
+strcasecmp(const char *p1, const char *p2)
 {
     while (*p1 && *p2) {
 	if (toupper(*p1) != toupper(*p2))
@@ -184,10 +172,7 @@ strcasecmp(p1, p2)
 #ifndef HAVE_MEMSET
 /* Public Domain memset(3) */
 char *
-memset(s, c, n)
-    char *s;
-    int c;
-    size_t n;
+memset(char *s, int c, size_t n)
 {
     char *p = s;
 

--- a/src/util.c
+++ b/src/util.c
@@ -216,7 +216,7 @@ char *
 xstrchr(const char *s, int c)
 {
     if (c == 0)
-        return s + strlen(s);
+        return (char*)s + strlen(s);
 
     while (*s) {
         if ((unsigned char)*s == (unsigned char)c)


### PR DESCRIPTION

[clang-make.log](https://github.com/user-attachments/files/24392153/clang-make.log)
Compiling with clang generates many warnings. This patch resolves this issue.
I have tested it with the following compilers:
- gcc 2.95.2, gcc 3.1 on Mac OS X 10.2
- gcc 3.3, gcc 4.0.1, gcc 4.2.1, llvm-gcc 4.2.1 on Mac OS X 10.5
- Apple clang version 17.0.0 (clang-1700.6.3.2) on macOS Tahoe 26.2