### PR TITLE
Fix buffer overflow in read_c_len

### DIFF
--- a/src/huf.c
+++ b/src/huf.c
@@ -399,7 +399,7 @@ read_c_len( /* void */ )
                     c = getbits(4) + 3;
                 else
                     c = getbits(CBIT) + 20;
-                while (--c >= 0)
+                while (--c >= 0 && i < NC)
                     c_len[i++] = 0;
             }
             else


### PR DESCRIPTION
## Summary

- add an `NC` bounds check while expanding zero-length code entries in `read_c_len()`

## Root cause

A crafted Huffman tree could request more zero entries than the `c_len[NC]` array can hold, allowing writes past the end of the global buffer.

## Impact

Malformed lh5/lh6/lh7 archives no longer write past `c_len` during decompression.

Fixes #63

## Verification

The following validation was performed:

- Created an lh5 reproduction archive that fills `c_len` to its limit and then requests an additional zero run.
- Confirmed with an instrumented pre-fix build that the out-of-bounds write beyond `c_len[NC]` is attempted.
- Processed the same archive with the patched binary built with AddressSanitizer enabled.
- Ran the existing test suite with `cd build && make check`.

The patched binary processed the reproduction archive successfully without an AddressSanitizer report. The existing test suite also completed successfully, confirming that the fix behaves as intended.
